### PR TITLE
Replicate emplace method of boost::optional

### DIFF
--- a/include/coruja/boost_optional.hpp
+++ b/include/coruja/boost_optional.hpp
@@ -121,6 +121,13 @@ public:
     { return !_observed; }
     
     BOOST_EXPLICIT_OPERATOR_BOOL_NOEXCEPT()
+
+    template <typename... Args>
+    void emplace(Args&&... args)
+    {
+        _observed.emplace(std::forward<Args>(args)...);
+        base::_after_change(base::as_derived());
+    }
     
     const T& get() const
     { return _observed.get(); }

--- a/test/boost_optional.cpp
+++ b/test/boost_optional.cpp
@@ -133,6 +133,32 @@ int main()
         BOOST_TEST(v2.get() == "abc");
     }
 
+    //optional.emplace(...)
+    {
+        struct NonMovable
+        {
+            NonMovable(NonMovable&&) = delete;
+            NonMovable& operator=(NonMovable&&) = delete;
+
+            NonMovable() = default;
+            NonMovable(std::string str) : str{std::move(str)}
+            {}
+
+            std::string str;
+        };
+
+        coruja::optional<NonMovable> v;
+        std::string str;
+
+        v.after_change
+            ([&](coruja::optional<NonMovable>& v)
+             { if(v) str = v.get().str; });
+
+        v.emplace("hello");
+
+        BOOST_TEST(str == "hello");
+    }
+
     //get() const
     {
         const optional_t o("abc");        


### PR DESCRIPTION
`boost::optional` has an `emplace()` method which allows constructing the contained object in place. This commit adds this method to `coruja::optional`, too.