### PR TITLE
Fixes typo in `T& coruja::optional<T>::get_value_or(T&)` and provides

### DIFF
--- a/include/coruja/boost_optional.hpp
+++ b/include/coruja/boost_optional.hpp
@@ -139,7 +139,7 @@ public:
     { return _observed.get_value_or(v); }
     
     T& get_value_or(T& v)
-    { return _observed.get_valure_or(v); }
+    { return _observed.get_value_or(v); }
     
     const observed_t& observed() const noexcept
     { return _observed; }

--- a/test/boost_optional.cpp
+++ b/test/boost_optional.cpp
@@ -180,7 +180,7 @@ int main()
     //get_value_or const
     {
         optional_t o; 
-        const optional_t& o_const{o};
+        const optional_t& o_const = o;
         optional_t::observed_t::value_type v("default");
         BOOST_TEST(o_const.get_value_or(v) == v);
 

--- a/test/boost_optional.cpp
+++ b/test/boost_optional.cpp
@@ -23,7 +23,7 @@ int main()
         static_assert(std::is_nothrow_default_constructible<optional_t>::value, "");
     }
 
-    //optiona(observed_t)
+    //optional(observed_t)
     {
         optional_t v(boost::optional<std::string>("abc"));
     }
@@ -164,5 +164,28 @@ int main()
         const optional_t o("abc");        
         BOOST_TEST(o);
         BOOST_TEST(o.get() == "abc");
+    }
+
+    //get_value_or
+    {
+        optional_t o; 
+        optional_t::observed_t::value_type v("default");
+        BOOST_TEST(o.get_value_or(v) == v);
+
+        o = "abc"; 
+        BOOST_TEST(o.get_value_or(v) == o.get());
+        
+    }
+
+    //get_value_or const
+    {
+        optional_t o; 
+        const optional_t& o_const{o};
+        optional_t::observed_t::value_type v("default");
+        BOOST_TEST(o_const.get_value_or(v) == v);
+
+        o = "abc"; 
+        BOOST_TEST(o_const.get_value_or(v) == o.get());
+        
     }
 }


### PR DESCRIPTION
tests for it